### PR TITLE
Fixes for LLL scene loading.

### DIFF
--- a/ChameleonCompat/RBMChameleonCompat.csproj
+++ b/ChameleonCompat/RBMChameleonCompat.csproj
@@ -10,54 +10,37 @@
     <RestoreAdditionalProjectSources>
       https://api.nuget.org/v3/index.json;
       https://nuget.bepinex.dev/v3/index.json;
-      https://nuget.samboy.dev/v3/index.json
+      https://nuget.samboy.dev/v3/index.json;
+      https://nuget.windows10ce.com/nuget/v3/index.json
     </RestoreAdditionalProjectSources>
     <RootNamespace>RebalancedMoons.ChameleonCompat</RootNamespace>
   </PropertyGroup>
 
+  <!-- Embedded debug. -->
+  <PropertyGroup>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" PrivateAssets="all" Publicize="true" />
+    <PackageReference Include="pacoito-LethalLevelLoaderUpdated" Version="1.5.*" PrivateAssets="all" />
+
+    <PackageReference Include="ButteryStancakes-Chameleon" Version="2.2.*" PrivateAssets="all" Publicize="true" />
+    <PackageReference Include="mrov.WeatherRegistry" Version="0.7.*" PrivateAssets="all" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 
-  
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.RenderPipelines.Core.Runtime" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.RenderPipelines.HighDefinition.Runtime" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.RenderPipelines.HighDefinition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="LethalLevelLoader" Publicize="true">
-      <HintPath>C:\Users\Stephanie\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\moon test\BepInEx\plugins\IAmBatby-LethalLevelLoader\LethalLevelLoader.dll</HintPath>
-    </Reference>
-    <Reference Include="WeatherRegistry">
-      <HintPath>C:\Users\Stephanie\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\moon test\BepInEx\plugins\mrov-WeatherRegistry\WeatherRegistry.dll</HintPath>
-    </Reference>
-    <Reference Include="Chameleon" Publicize="true">
-      <HintPath>C:\Users\Stephanie\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\moon test\BepInEx\plugins\ButteryStancakes-Chameleon\Chameleon.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -14,6 +14,9 @@ namespace RebalancedMoons
         internal static ConfigEntry<bool> configWeatherOverrides, configMoonPriceOverrides, configEmbrionBoulders, configEmbrionGambling;
         internal static void Init(ConfigFile cfg)
         {
+            // Disable saving config after a call to 'Bind()' is made.
+            cfg.SaveOnConfigSet = false;
+
             // -client settings-
 
             configTitanLighting = cfg.Bind("Client", "Titan Lighting", true,
@@ -92,6 +95,13 @@ namespace RebalancedMoons
 
             configMoonPriceOverrides = cfg.Bind("Server", "Price Overrides", true,
                 new ConfigDescription("Enables price overrides on rebalanced moons"));
+
+            // Remove old config settings.
+            cfg.OrphanedEntries.Clear();
+
+            // Re-enable saving and save config.
+            cfg.SaveOnConfigSet = true;
+            cfg.Save();
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -16,12 +16,13 @@ using UnityEngine.Rendering.HighDefinition;
 namespace RebalancedMoons
 {
     [BepInPlugin(PLUGIN_GUID, PLUGIN_NAME, PLUGIN_VERSION)]
+    [BepInDependency(LETHAL_LEVEL_LOADER, BepInDependency.DependencyFlags.HardDependency)]
     [BepInDependency(WEATHER_REGISTRY, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(LOBBY_COMPATIBILITY, BepInDependency.DependencyFlags.SoftDependency)]
     public class Plugin : BaseUnityPlugin
     {
         public static Plugin Instance { get; set; }
-        public const string PLUGIN_GUID = "dopadream.lethalcompany.rebalancedmoons", PLUGIN_NAME = "RebalancedMoons", PLUGIN_VERSION = "1.16.0", WEATHER_REGISTRY = "mrov.WeatherRegistry", LOBBY_COMPATIBILITY = "BMX.LobbyCompatibility";
+        public const string PLUGIN_GUID = "dopadream.lethalcompany.rebalancedmoons", PLUGIN_NAME = "RebalancedMoons", PLUGIN_VERSION = "1.16.0", WEATHER_REGISTRY = "mrov.WeatherRegistry", LOBBY_COMPATIBILITY = "BMX.LobbyCompatibility", LETHAL_LEVEL_LOADER = "imabatby.lethallevelloader";
         internal static new ManualLogSource Logger;
         internal static ExtendedMod rebalancedMoonsMod;
         internal static SpawnableOutsideObject embrionBoulder1, embrionBoulder2, embrionBoulder3, embrionBoulder4;
@@ -62,8 +63,6 @@ namespace RebalancedMoons
             var embrionBundleFilePath = Path.Combine(dllFolderPath, "embrionboulders");
             EmbrionBundle = AssetBundle.LoadFromFile(embrionBundleFilePath);
 
-            NetcodePatcher();
-
             AssetBundleLoader.AddOnExtendedModLoadedListener(OnExtendedModRegistered, "dopadream", "RebalancedMoons");
 
             Harmony harmony = new Harmony(PLUGIN_GUID);
@@ -82,24 +81,6 @@ namespace RebalancedMoons
 
         }
 
-
-        private static void NetcodePatcher()
-        {
-            var types = Assembly.GetExecutingAssembly().GetTypes();
-            foreach (var type in types)
-            {
-                var methods = type.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
-                foreach (var method in methods)
-                {
-                    var attributes = method.GetCustomAttributes(typeof(RuntimeInitializeOnLoadMethodAttribute), false);
-                    if (attributes.Length > 0)
-                    {
-                        method.Invoke(null, null);
-                    }
-                }
-            }
-        }
-
         internal static void OnExtendedModRegistered(ExtendedMod extendedMod)
         {
             if (extendedMod == null) return;
@@ -108,16 +89,11 @@ namespace RebalancedMoons
 
 
 
-
+        [HarmonyPatch]
         internal class RebalancedMoonsPatches
         {
             static void InitMoons()
             {
-                if (!LethalLevelLoader.Plugin.IsSetupComplete)
-                {
-                    return;
-                }
-
                 foreach (ExtendedLevel extendedLevel in PatchedContent.VanillaExtendedLevels)
                 {
                     SwapScene(extendedLevel);
@@ -174,12 +150,11 @@ namespace RebalancedMoons
                 }
             }
 
-            [HarmonyPatch(typeof(QuickMenuManager), nameof(QuickMenuManager.Start))]
-            [HarmonyPostfix]
-            static void SubscribeToHandler()
+            [HarmonyPrepare]
+            static void SubscribeToHandler(MethodBase original)
             {
-                RBMNetworker.SendLevelEvent += RebalancedMoonsPatches.ReceivedLevelFromServer;
-                SetupLobby(StartOfRound.Instance);
+                if (original == null)
+                    LethalLevelLoader.Plugin.onLobbyInitialized += SetupLobby;
             }
 
             [HarmonyPatch(typeof(QuickMenuManager), nameof(QuickMenuManager.LeaveGameConfirm))]
@@ -189,15 +164,16 @@ namespace RebalancedMoons
                 RBMNetworker.SendLevelEvent -= RebalancedMoonsPatches.ReceivedLevelFromServer;
             }
 
-            [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.OnClientConnect))]
+            /* [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.OnClientConnect))]
             [HarmonyPostfix]
             static void ClientConnectPostFix(StartOfRound __instance)
             {
-                SetupLobby(__instance);
-            }
+                SetupLobby();
+            } */
 
-            static void SetupLobby(StartOfRound __instance)
+            static void SetupLobby()
             {
+                RBMNetworker.SendLevelEvent += RebalancedMoonsPatches.ReceivedLevelFromServer;
 
                 // yeah i know this is weird ok just leaving this method here in case i want to add anything extra 
 

--- a/RBMNetworker.cs
+++ b/RBMNetworker.cs
@@ -48,6 +48,9 @@ namespace RebalancedMoons
                 // register it, and then it can be spawned
                 NetworkManager.Singleton.AddNetworkPrefab(networkPrefab);
 
+                // spawn before LLL starts loading content
+                LethalLevelLoader.Plugin.onBeforeSetup += Create;
+
                 Plugin.Logger.LogDebug("Successfully registered network handler. This is good news!");
             }
             catch (System.Exception e)
@@ -90,14 +93,6 @@ namespace RebalancedMoons
                 Instance = this;
             }
             Plugin.Logger.LogDebug("Successfully spawned network handler.");
-        }
-
-
-        [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.Awake))]
-        [HarmonyPostfix]
-        public static void StartOfRoundWake()
-        {
-            Create();
         }
 
         void Start()
@@ -251,7 +246,7 @@ namespace RebalancedMoons
                             level.SelectableLevel.spawnableScrap.Clear();
                             foreach (var item in StartOfRound.Instance.allItemsList.itemsList)
                             {
-                                if (!item.twoHanded && item.isScrap)
+                                if (item != null && !item.twoHanded && item.isScrap)
                                 {
 
                                     if (item.isDefensiveWeapon && item.itemName != "Stop sign" && item.itemName != "Yield sign")

--- a/RebalancedMoons.csproj
+++ b/RebalancedMoons.csproj
@@ -10,9 +10,17 @@
     <RestoreAdditionalProjectSources>
       https://api.nuget.org/v3/index.json;
       https://nuget.bepinex.dev/v3/index.json;
-      https://nuget.samboy.dev/v3/index.json
+      https://nuget.samboy.dev/v3/index.json;
+      https://nuget.windows10ce.com/nuget/v3/index.json
     </RestoreAdditionalProjectSources>
     <RootNamespace>RebalancedMoons</RootNamespace>
+  </PropertyGroup>
+
+  <!-- Embedded debug. -->
+  <PropertyGroup>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,49 +31,26 @@
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" PrivateAssets="all" Publicize="true" />
+    <PackageReference Include="pacoito-LethalLevelLoaderUpdated" Version="1.5.*" PrivateAssets="all" />
+
+    <PackageReference Include="TeamBMX.LobbyCompatibility" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="mrov.WeatherRegistry" Version="0.7.*" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
   	<Exec Command="netcode-patch -uv 2022.3.62 -nv 1.12.0 -tv 1.0.0 &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')" />
   </Target>
-  
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.RenderPipelines.Core.Runtime" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.RenderPipelines.Core.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.RenderPipelines.HighDefinition.Runtime" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.RenderPipelines.HighDefinition.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Netcode.Runtime" Publicize="true">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="LethalLevelLoader" Publicize="true">
-      <HintPath>C:\Users\Owner\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\Default\BepInEx\plugins\IAmBatby-LethalLevelLoader\LethalLevelLoader.dll</HintPath>
-    </Reference>
-    <Reference Include="WeatherRegistry">
-      <HintPath>C:\Users\Owner\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\Default\BepInEx\plugins\mrov-WeatherRegistry\WeatherRegistry.dll</HintPath>
-    </Reference>
-    <Reference Include="Chameleon" Publicize="true">
-      <HintPath>C:\Users\Owner\AppData\Roaming\com.kesomannen.gale\lethal-company\profiles\Default\BepInEx\plugins\ButteryStancakes-Chameleon\Chameleon.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-<ItemGroup>
-    <PackageReference Include="TeamBMX.LobbyCompatibility" Version="1.*" PrivateAssets="all" />
-</ItemGroup>
+
 </Project>

--- a/RebalancedMoons.csproj
+++ b/RebalancedMoons.csproj
@@ -35,6 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="BepInEx.BaseLib" Version="5.*" PrivateAssets="all" Publicize="true" />
     <PackageReference Include="BepInEx.Core" Version="5.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />

--- a/RebalancedMoons.csproj
+++ b/RebalancedMoons.csproj
@@ -40,10 +40,10 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" PrivateAssets="all" Publicize="true" />
-    <PackageReference Include="pacoito-LethalLevelLoaderUpdated" Version="1.5.*" PrivateAssets="all" />
+    <PackageReference Include="IAmBatby-LethalLevelLoader" Version="1.6.8" PrivateAssets="all" />
 
     <PackageReference Include="TeamBMX.LobbyCompatibility" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="mrov.WeatherRegistry" Version="0.7.*" PrivateAssets="all" />
+    <PackageReference Include="mrov.WeatherRegistry" Version="0.8.*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">

--- a/RebalancedMoons.sln
+++ b/RebalancedMoons.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.4.33403.182
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RebalancedMoons", "RebalancedMoons.csproj", "{51CDA42D-EABB-4867-AF7D-28627AA62707}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RBMChameleonCompat", "ChameleonCompat\RBMChameleonCompat.csproj", "{A6CACB10-1E78-423B-BF2A-9F87626FC3BF}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{45262A9C-C597-432A-A2A4-89A0FA3DD97A}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -20,6 +22,10 @@ Global
 		{51CDA42D-EABB-4867-AF7D-28627AA62707}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51CDA42D-EABB-4867-AF7D-28627AA62707}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51CDA42D-EABB-4867-AF7D-28627AA62707}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6CACB10-1E78-423B-BF2A-9F87626FC3BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6CACB10-1E78-423B-BF2A-9F87626FC3BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6CACB10-1E78-423B-BF2A-9F87626FC3BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6CACB10-1E78-423B-BF2A-9F87626FC3BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Switched scene changes from `QuickMenuManager.Start()` to LLL's `onLobbyInitialized` event, should remove the need for [LLLHotreloadPatch](https://thunderstore.io/c/lethal-company/p/dopadream/LLLHotreloadPatch) as a dependency.

Cherry picked from some old commits that I have not tested it in a while, also I forget if there was a (critical) reason I started reworking the networking...

Also should probably undo the changes to .csproj if looking into updating it for `v80`, given that the GameLibs package is not yet updated.